### PR TITLE
fix: #1 Implement distinct style for image captions

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -308,11 +308,32 @@ figure.original-size img {
 }
 
 .post__image {
+    background-color: hsl(from currentColor h s 95%);
     margin: 0;
-    & img {
-        width: 100%;
-        aspect-ratio: 16 / 9;
-        object-fit: cover;
+    display: inline-block;
+
+    & > a {
+        display: block;
+        font-size: 0;
+
+        & img {
+            width: 100%;
+            aspect-ratio: 16 / 9;
+            object-fit: cover;
+        }
+    }
+
+    & figcaption {
+        margin-inline: 1rem;
+        line-height: 1.2;
+
+        & p:first-child {
+            margin-top: 0.25rem;
+        }
+
+        & p:last-child {
+            margin-bottom: 0.25rem;
+        }
     }
 }
 

--- a/docs/css/style.css
+++ b/docs/css/style.css
@@ -308,11 +308,32 @@ figure.original-size img {
 }
 
 .post__image {
+    background-color: hsl(from currentColor h s 95%);
     margin: 0;
-    & img {
-        width: 100%;
-        aspect-ratio: 16 / 9;
-        object-fit: cover;
+    display: inline-block;
+
+    & > a {
+        display: block;
+        font-size: 0;
+
+        & img {
+            width: 100%;
+            aspect-ratio: 16 / 9;
+            object-fit: cover;
+        }
+    }
+
+    & figcaption {
+        margin-inline: 1rem;
+        line-height: 1.2;
+
+        & p:first-child {
+            margin-top: 0.25rem;
+        }
+
+        & p:last-child {
+            margin-bottom: 0.25rem;
+        }
     }
 }
 


### PR DESCRIPTION
I tweaked the margins on the `<figcaption>` element and the first and last `<p>` within it. I also gave it a slight background color.

The background color is based on `currentColor`. I'm hoping this will make it easier when I do something more robust with color schemes.